### PR TITLE
update for facets 1.6, lock version to keep 'er safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "description": "DGI's IR customizations",
   "type": "drupal-module",
   "require": {
-    "discoverygarden/islandora_institutional_repository": "*"
+    "discoverygarden/islandora_institutional_repository": "*",
+    "drupal/facets": "~1.6"
   },
   "license": "GPL-3.0-only"
 }

--- a/dgi_ir_customizations.info.yml
+++ b/dgi_ir_customizations.info.yml
@@ -5,3 +5,4 @@ package: DGI Helpers
 core: 8.x
 dependencies:
   - islandora_institutional_repository
+  - facets

--- a/src/Plugin/facets/url_processor/DgiIrCustomizationsQueryString.php
+++ b/src/Plugin/facets/url_processor/DgiIrCustomizationsQueryString.php
@@ -164,7 +164,6 @@ class DgiIrCustomizationsQueryString extends QueryString {
           $new_url_params['search_api_fulltext'] = '';
         }
 
-
         // Set the new url parameters.
         $url->setOption('query', $new_url_params);
       }

--- a/src/Plugin/facets/url_processor/DgiIrCustomizationsQueryString.php
+++ b/src/Plugin/facets/url_processor/DgiIrCustomizationsQueryString.php
@@ -144,9 +144,6 @@ class DgiIrCustomizationsQueryString extends QueryString {
 
       asort($filter_params, \SORT_NATURAL);
       $result_get_params->set($this->filterKey, array_values($filter_params));
-      if (!empty($routeParameters)) {
-        $url->setRouteParameters($routeParameters);
-      }
 
       if ($result_get_params->all() !== [$this->filterKey => []]) {
         $new_url_params = $result_get_params->all();

--- a/src/Plugin/facets/url_processor/DgiIrCustomizationsQueryString.php
+++ b/src/Plugin/facets/url_processor/DgiIrCustomizationsQueryString.php
@@ -45,7 +45,6 @@ class DgiIrCustomizationsQueryString extends QueryString {
     $facet_source_path = $facet->getFacetSource()->getPath();
     $request = $this->getRequestByFacetSourcePath($facet_source_path);
     $requestUrl = $this->getUrlForRequest($facet_source_path, $request);
-    $routeParameters = $this->getUrlRouteParameters();
 
     $original_filter_params = [];
     foreach ($this->getActiveFilters() as $facet_id => $values) {
@@ -167,6 +166,7 @@ class DgiIrCustomizationsQueryString extends QueryString {
         if (!isset($new_url_params['search_api_fulltext'])) {
           $new_url_params['search_api_fulltext'] = '';
         }
+
 
         // Set the new url parameters.
         $url->setOption('query', $new_url_params);


### PR DESCRIPTION
Looking at this, this seems kind of bizarre. They nuked the `getUrlRouteParameters()` function, then nuked the reference to it ... but they're still checking for the existence of a `$routeParameters` variable which no longer exists. So it's always gonna tell them it doesn't exist. Seems like some kind of half-baked change. Or maybe `getUrlRouteParams()` never did anything, so nuking it has no effect. Anyway ...